### PR TITLE
Volviendo al tema nord

### DIFF
--- a/kitty/colors.conf
+++ b/kitty/colors.conf
@@ -1,0 +1,22 @@
+
+
+foreground   #abcac2
+background   #060C11
+cursor       #F09383
+
+color0       #060C11
+color8       #778d87
+color1       #5F6054
+color9       #5F6054
+color2       #9D2B25
+color10      #9D2B25
+color3       #AA554D
+color11      #AA554D
+color4       #DB635D
+color12      #DB635D
+color5       #6E8974
+color13      #6E8974
+color6       #B88977
+color14      #B88977
+color7       #abcac2
+color15      #abcac2

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -18,12 +18,12 @@
 #: families that have many weight variants like Book, Medium, Thick,
 #: etc. For example::
 
-font_family      IBM Plex Mono Text
-     bold_font   IBM Plex Mono SemiBold
+font_family      Cartograph CF Light
+     bold_font   Cartograph CF Bold
      italic_font Cartograph CF Light Italic
      bold_italic_font Cartograph CF Bold Italic
 
-font_size 12.0
+font_size 13.0
 
 #: Font size (in pts)
 
@@ -46,7 +46,7 @@ font_size 12.0
 #: support, because it will force kitty to always treat the text as
 #: LTR, which FriBidi expects for terminals.
 
- adjust_line_height  -1
+ adjust_line_height 0 
 # adjust_column_width 0
 
 #: Change the size of each character cell kitty renders. You can use
@@ -761,7 +761,9 @@ enable_audio_bell yes
 #include sonokai-atlantis.conf
 #include sonokai-shusia.conf
 # include sonokai-maia.conf
-include theme.conf
+#include nord.conf
+#include theme.conf
+include colors.conf
 
 #foreground #D8DEE9
 #background #2E3440

--- a/kitty/nord.conf
+++ b/kitty/nord.conf
@@ -1,0 +1,38 @@
+foreground            #D8DEE9
+background            #242933
+selection_foreground  #000000
+selection_background  #FFFACD
+url_color             #0087BD
+cursor                #81A1C1
+
+# black
+color0   #3B4252
+color8   #4C566A
+
+# red
+color1   #BF616A
+color9   #BF616A
+
+# green
+color2   #A3BE8C
+color10  #A3BE8C
+
+# yellow
+color3   #EBCB8B
+color11  #EBCB8B
+
+# blue
+color4  #81A1C1
+color12 #81A1C1
+
+# magenta
+color5   #B48EAD
+color13  #B48EAD
+
+# cyan
+color6   #88C0D0
+color14  #8FBCBB
+
+# white
+color7   #E5E9F0
+color15  #ECEFF4

--- a/kitty/theme.conf
+++ b/kitty/theme.conf
@@ -1,1 +1,1 @@
-./kitty-themes/themes/ayu.conf
+./kitty-themes/themes/Hybrid.conf


### PR DESCRIPTION
Debido a errores en el tema color decidimos cambiar al tema nord por motivos de fallos a la hora de la documentación. El tema horizon mostraba los colores al contrario y tenia muchos conflictos con nuestra configuración